### PR TITLE
Allow explicitly setting Direct Line domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For agents requiring authentication, use the [BotFramework WebChat SDK](https://
 | `data-webchat-preload` | `false` | Load conversation on page load (even if minimized) |
 | `data-webchat-send-start-event` | `true` | Send `startConversation` event to trigger welcome message |
 | `data-webchat-mock-welcome` | *(none)* | Show a client-side mock welcome message instead of calling the agent |
+| `data-webchat-domain` | *(default)* | Custom Direct Line domain URL (e.g., for regional endpoints or Azure Government) |
 
 ### User Identity
 

--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,13 @@
    */
   async function renderChat(chatContainer, element, tokenUrl, sendStartEvent, mockWelcome) {
     const token = await fetchToken(tokenUrl);
-    const directLine = window.WebChat.createDirectLine({ token });
+
+    // Build DirectLine options
+    const directLineOptions = { token };
+    const domain = element.getAttribute(`${ATTR_PREFIX}domain`);
+    if (domain) directLineOptions.domain = domain;
+
+    const directLine = window.WebChat.createDirectLine(directLineOptions);
 
     const options = {
       directLine,


### PR DESCRIPTION
Added a  new attribute `data-webchat-domain` for the domain to be explicitly set in html.
Added code to read the attribute and send the domain as part of the _createDirectLine_ call.

Closes #4 